### PR TITLE
Fix alternate game width bug in Connect4 constructor.

### DIFF
--- a/connect4.py
+++ b/connect4.py
@@ -15,8 +15,8 @@ class Connect4:
  
         self.score = None
         self.state = np.zeros(size, dtype = np.float)
-        self.openCells = [0]*7
-        self.available_moves = [0, 1, 2, 3, 4, 5, 6]
+        self.openCells = [0]*self.w
+        self.available_moves = list(range(self.w))  # array of possible moves.
         self.player = 1
         self.last_move = None
         self.n_moves = 0


### PR DESCRIPTION
In the original code, the game width is hard-coded into the Connect4 constructor. This code suggestion allows for any width as provided by the size initiation parameter.  